### PR TITLE
Add annotations for `chrome.notifications`

### DIFF
--- a/interfaces/Chrome.js
+++ b/interfaces/Chrome.js
@@ -19,6 +19,7 @@ declare var chrome: {
   idle: chrome$idle,
   instanceID: chrome$instanceID,
   networking: chrome$networking,
+  notifications: chrome$notifications,
   pageAction: chrome$pageAction,
   permissions: chrome$permissions,
   power: chrome$power,

--- a/interfaces/notifications.js
+++ b/interfaces/notifications.js
@@ -31,11 +31,17 @@ type chrome$NotificationOptions = {
 
 type chrome$notifications = {
   clear(notificationId: string, callback?: (wasCleared: boolean) => void): void,
-  create(
-    notificationIdOrOptions: string | chrome$NotificationOptions,
-    optionsOrCallback?: chrome$NotificationOptions | (notificationId: string) => void,
-    callback?: (notificationId: string) => void
-  ): void,
+  create: (
+    ((
+      notificationId: string,
+      options: chrome$NotificationOptions,
+      callback?: (notificationId: string) => void
+    ) => void) &
+    ((
+      options: chrome$NotificationOptions,
+      callback?: (notificationId: string) => void
+    ) => void)
+  ),
   getAll(callback: (notifications: Object) => void): void,
   getPermissionLevel(callback: (level: chrome$PermissionLevel) => void): void,
   update(notificationId: string, options: chrome$NotificationOptions, callback?: (wasUpdated: boolean) => void): void,

--- a/interfaces/notifications.js
+++ b/interfaces/notifications.js
@@ -1,0 +1,58 @@
+type chrome$TemplateType = 'basic' | 'image' | 'list' | 'progress';
+
+type chrome$PermissionLevel = 'denied' | 'granted';
+
+type chrome$NotificationButton = {
+  iconUrl?: string,
+  title: string,
+};
+
+type chrome$NotificationItem = {
+  message: string,
+  title: string,
+};
+
+type chrome$NotificationOptions = {
+  appIconMaskUrl?: string,
+  buttons?: Array<chrome$NotificationButton>,
+  contextMessage?: string,
+  eventTime?: number,
+  iconUrl?: string,
+  imageUrl?: string,
+  isClickable?: boolean,
+  items?: Array<chrome$NotificationItem>,
+  message?: string,
+  priority?: number,
+  progress?: number,
+  requireInteraction?: boolean,
+  title?: string,
+  type?: chrome$TemplateType,
+};
+
+type chrome$notifications = {
+  clear(notificationId: string, callback?: (wasCleared: boolean) => void): void,
+  create(
+    notificationIdOrOptions: string | chrome$NotificationOptions,
+    optionsOrCallback?: chrome$NotificationOptions | (notificationId: string) => void,
+    callback?: (notificationId: string) => void
+  ): void,
+  getAll(callback: (notifications: Object) => void): void,
+  getPermissionLevel(callback: (level: chrome$PermissionLevel) => void): void,
+  update(notificationId: string, options: chrome$NotificationOptions, callback?: (wasUpdated: boolean) => void): void,
+
+  onButtonClicked: chrome$Event & {
+    addListener(callback: (notificationId: string, buttonIndex: number) => void): void,
+  },
+  onClicked: chrome$Event & {
+    addListener(callback: (notificationId: string) => void): void,
+  },
+  onClosed: chrome$Event & {
+    addListener(callback: (notificationId: string, byUser: boolean) => void): void,
+  },
+  onPermissionLevelChanged: chrome$Event & {
+    addListener(callback: (level: chrome$PermissionLevel) => void): void,
+  },
+  onShowSettings: chrome$Event & {
+    addListener(callback: () => void): void,
+  },
+};


### PR DESCRIPTION
[chrome.notifications][1]

* `chrome.notifications.create` has a signature best described using
  unions for each of its parameters rather than a union of multiple
  full function signatures.

[1]: https://developer.chrome.com/apps/notifications