### PR TITLE
Add `extension` and `extensionTypes`

### DIFF
--- a/interfaces/Chrome.js
+++ b/interfaces/Chrome.js
@@ -14,6 +14,7 @@ declare var chrome: {
   devtools: chrome$devtools,
   documentScan: chrome$documentScan,
   downloads: chrome$downloads,
+  extension: chrome$extension,
   extensionTypes: chrome$extensionTypes,
   fileBrowserHandler: chrome$fileBrowserHandler,
   fontSettings: chrome$fontSettings,

--- a/interfaces/Chrome.js
+++ b/interfaces/Chrome.js
@@ -14,6 +14,7 @@ declare var chrome: {
   devtools: chrome$devtools,
   documentScan: chrome$documentScan,
   downloads: chrome$downloads,
+  extensionTypes: chrome$extensionTypes,
   fileBrowserHandler: chrome$fileBrowserHandler,
   fontSettings: chrome$fontSettings,
   idle: chrome$idle,

--- a/interfaces/extension.js
+++ b/interfaces/extension.js
@@ -1,0 +1,17 @@
+type chrome$ViewType = 'tab' | 'popup';
+
+type chrome$extension = {
+  inIncognitoContext: boolean,
+  lastError: ?{message: string},
+
+  getBackgroundPage(): ?any,
+  getURL(path: string): string,
+  getViews(fetchProperties?: {
+    tabId?: number,
+    type?: chrome$ViewType,
+    windowId?: number,
+  }): Array<any>,
+  isAllowedFileSchemeAccess(callback: (isAllowedAccess: boolean) => void): void,
+  isAllowedIncognitoAccess(callback: (isAllowedAccess: boolean) => void): void,
+  setUpdateUrlData(data: string): void,
+};

--- a/interfaces/extension.js
+++ b/interfaces/extension.js
@@ -2,9 +2,9 @@ type chrome$ViewType = 'tab' | 'popup';
 
 type chrome$extension = {
   inIncognitoContext: boolean,
-  lastError: ?{message: string},
+  lastError: {message: string} | void,
 
-  getBackgroundPage(): ?any,
+  getBackgroundPage(): any,
   getURL(path: string): string,
   getViews(fetchProperties?: {
     tabId?: number,

--- a/interfaces/extensionTypes.js
+++ b/interfaces/extensionTypes.js
@@ -15,3 +15,10 @@ type chrome$InjectDetails = {
   matchAboutBlank?: boolean,
   runAt?: chrome$RunAt
 };
+
+type chrome$extensionTypes = {
+  ImageDetails: chrome$ImageDetails,
+  ImageFormat: chrome$ImageFormat,
+  InjectDetails: chrome$InjectDetails,
+  RunAt: chrome$RunAt,
+};


### PR DESCRIPTION
* Add the type for [`chrome.extension`][1]
* Expose `chrome.extensionTypes`, which already existed, on the `chrome` object

[1]: https://developer.chrome.com/extensions/extension