### PR TITLE
Camelcase "favIconUrl" the same as tab API

### DIFF
--- a/interfaces/tabs.js
+++ b/interfaces/tabs.js
@@ -9,7 +9,7 @@ type chrome$MutedInfoReason = 'capture' | 'extension' | 'user';
 type chrome$Tab = {
   active: boolean,
   audible?: boolean,
-  faviconUrl?: string,
+  favIconUrl?: string,
   height?: number,
   highlighted: boolean,
   id?: number,
@@ -298,7 +298,7 @@ type chrome$tabs = {
       tabId: number,
       changeInfo: {
         audible?: boolean,
-        faviconUrl?: string,
+        favIconUrl?: string,
         mutedInfo?: chrome$MutedInfo,
         pinned?: boolean,
         status?: string,


### PR DESCRIPTION
The [tab API](https://developer.chrome.com/extensions/tabs) uses camelcase, with a capital 'I', for its `favIconUrl`. This is different than the lowercase `faviconUrl` used by the debugger's [TargetInfo](https://developer.chrome.com/extensions/debugger#type-TargetInfo).