### PR TITLE
Add types for chrome.i18n

### DIFF
--- a/interfaces/Chrome.js
+++ b/interfaces/Chrome.js
@@ -18,6 +18,7 @@ declare var chrome: {
   extensionTypes: chrome$extensionTypes,
   fileBrowserHandler: chrome$fileBrowserHandler,
   fontSettings: chrome$fontSettings,
+  i18n: chrome$i18n,
   idle: chrome$idle,
   instanceID: chrome$instanceID,
   networking: chrome$networking,

--- a/interfaces/i18n.js
+++ b/interfaces/i18n.js
@@ -1,14 +1,18 @@
 type chrome$LanguageCode = string;
 
+type chrome$DetectedLanguage = {
+  language: chrome$LanguageCode,
+  percentage: number,
+};
+
+type chrome$LanguageDetectionResult = {
+  isReliable: boolean,
+  languages: Array<chrome$DetectedLanguage>,
+};
+
 type chrome$i18n = {
-  getAcceptLanguages(callback: (Array<chrome$LanguageCode>) => void): void,
-  getMessage(messageName: string, ...substitutions?: Array<*>): ?string,
+  getAcceptLanguages(callback: (languages: Array<chrome$LanguageCode>) => void): void,
+  getMessage: (messageName: string, substitutions?: string | Array<string>) => string,
   getUILanguage(): string,
-  detectLanguage(text: string, callback: (result: {
-    isReliable: boolean,
-    languages: {
-      language: chrome$LanguageCode,
-      percentage: number,
-    },
-  }) => void): void,
+  detectLanguage(text: string, callback: (result: chrome$LanguageDetectionResult) => void): void,
 };

--- a/interfaces/i18n.js
+++ b/interfaces/i18n.js
@@ -1,0 +1,14 @@
+type chrome$LanguageCode = string;
+
+type chrome$i18n = {
+  getAcceptLanguages(callback: (Array<chrome$LanguageCode>) => void): void,
+  getMessage(messageName: string, ...substitutions?: Array<*>): ?string,
+  getUILanguage(): string,
+  detectLanguage(text: string, callback: (result: {
+    isReliable: boolean,
+    languages: {
+      language: chrome$LanguageCode,
+      percentage: number,
+    },
+  }) => void): void,
+};

--- a/interfaces/i18n.js
+++ b/interfaces/i18n.js
@@ -12,7 +12,7 @@ type chrome$LanguageDetectionResult = {
 
 type chrome$i18n = {
   getAcceptLanguages(callback: (languages: Array<chrome$LanguageCode>) => void): void,
-  getMessage: (messageName: string, substitutions?: string | Array<string>) => string,
+  getMessage(messageName: string, substitutions?: string | Array<string>): ?string,
   getUILanguage(): string,
   detectLanguage(text: string, callback: (result: chrome$LanguageDetectionResult) => void): void,
 };


### PR DESCRIPTION
Add unimplemented types for [`chrome.i18n`][0]. Types are all based off
Chrome's documentation.

Addresses #1

[0]: https://developer.chrome.com/extensions/i18n