### PR TITLE
Add referenced `onErrorOccurredOptions` type

### DIFF
--- a/interfaces/webRequest.js
+++ b/interfaces/webRequest.js
@@ -24,6 +24,7 @@ type chrome$OnAuthRequiredOptions =
 type chrome$OnResponseStartedOptions = 'responseHeaders';
 type chrome$OnBeforeRedirectOptions = 'responseHeaders';
 type chrome$OnCompletedOptions = 'responseHeaders';
+type chrome$OnErrorOccurredOptions = void;
 type chrome$RequestFilter = {
   urls: Array<string>,
   types?: Array<chrome$ResourceType>,


### PR DESCRIPTION
According to the [`webrequest` docs][0], there are no possible options
for `onErrorOccurred`. Since it still uses the `addListener` interface
it can receive an options Array, but since there are no valid options
typing it as `Array<void>` ensures only an empty Array is allowed.

Fixes #17

[0]: https://developer.chrome.com/extensions/webRequest#toc