### PR TITLE
Allow `null` for storage.get to get all data

### DIFF
--- a/interfaces/storage.js
+++ b/interfaces/storage.js
@@ -6,7 +6,7 @@ type chrome$StorageChange = {
 type chrome$StorageArea = {
   clear(callback?: () => void): void,
   get: (
-    ((keys: string | Array<string> | Object, callback: (items: Object) => void) => void) &
+    ((keys: string | Array<string> | Object | null, callback: (items: Object) => void) => void) &
     ((callback: (items: Object) => void) => void)
   ),
   getBytesInUse: (


### PR DESCRIPTION
Per the [`StorageArea.get` docs][0], you can pass `null` as the first
parameter in order to get the entire contents of the storage. `null` is
a valid value for `keys`.

From the docs:

> Pass in `null` to get the entire contents of storage.

[0]: https://developer.chrome.com/extensions/storage#method-StorageArea-get