### PR TITLE
Replace intersection with union in runtime.onMessage

### DIFF
--- a/interfaces/runtime.js
+++ b/interfaces/runtime.js
@@ -93,7 +93,7 @@ type chrome$runtime = {
         message: any,
         sender: chrome$MessageSender,
         sendResponse: () => void
-      ) => true | void) &
+      ) => true | void) |
       ((
         sender: chrome$MessageSender,
         sendResponse: () => void
@@ -106,7 +106,7 @@ type chrome$runtime = {
         message: any,
         sender: chrome$MessageSender,
         sendResponse: () => void
-      ) => true | void) &
+      ) => true | void) |
       ((
         sender: chrome$MessageSender,
         sendResponse: () => void


### PR DESCRIPTION
Flow currently throws an error for `onMessage` listener registration

![image](https://user-images.githubusercontent.com/15238587/45064388-50979980-b068-11e8-8339-2867fb51863c.png)

It seems to me this says a listener callback must conform to 

```javascript
(any, chrome$MessageSender, sendResponse: () => void)
```

_and_

```javascript
(chrome$MessageSender, sendResponse: () => void)
```

This changes makes it so that either case is acceptable.