### PR TITLE
 Fix chrome.runtime.connect signature

### DIFF
--- a/interfaces/runtime.js
+++ b/interfaces/runtime.js
@@ -37,10 +37,8 @@ type chrome$runtime = {
   id: string,
   lastError: {message?: string},
 
-  connect(extensionId?: string, connectInfo?: {
-    includeTlsChannelId?: boolean,
-    name?: string
-  }): chrome$Port,
+  connect(extensionId: string, connectInfo?: chrome$connectInfo): chrome$Port,
+  connect(connectInfo?: chrome$connectInfo): chrome$Port,
   connectNative(application: string): chrome$Port,
   getBackgroundPage(callback: (backgroundPage: any) => void): void,
   getManifest(): Object,

--- a/interfaces/runtime.js
+++ b/interfaces/runtime.js
@@ -33,6 +33,11 @@ type chrome$OnInstalledReason = 'chrome_update' | 'install' | 'shared_module_upd
 
 type chrome$OnRestartRequiredReason = 'app_update' | 'os_update' | 'periodic';
 
+type chrome$connectInfo = {
+  includeTlsChannelId?: boolean,
+  name?: string
+};
+
 type chrome$runtime = {
   id: string,
   lastError: {message?: string},

--- a/interfaces/runtime.js
+++ b/interfaces/runtime.js
@@ -33,7 +33,7 @@ type chrome$OnInstalledReason = 'chrome_update' | 'install' | 'shared_module_upd
 
 type chrome$OnRestartRequiredReason = 'app_update' | 'os_update' | 'periodic';
 
-type chrome$connectInfo = {
+type chrome$ConnectInfo = {
   includeTlsChannelId?: boolean,
   name?: string
 };
@@ -42,8 +42,8 @@ type chrome$runtime = {
   id: string,
   lastError: {message?: string},
 
-  connect(extensionId: string, connectInfo?: chrome$connectInfo): chrome$Port,
-  connect(connectInfo?: chrome$connectInfo): chrome$Port,
+  connect(extensionId: string, connectInfo?: chrome$ConnectInfo): chrome$Port,
+  connect(connectInfo?: chrome$ConnectInfo): chrome$Port,
   connectNative(application: string): chrome$Port,
   getBackgroundPage(callback: (backgroundPage: any) => void): void,
   getManifest(): Object,


### PR DESCRIPTION
The signature was previously typed like this:

```jsx
connect(extensionId?: string, connectInfo?: { ... })
```

On the surface this looks like what the [official docs](https://developer.chrome.com/extensions/runtime#method-connect) say, but it's not. The official docs say the first argument is optional, which means it effectively has multiple signatures: you can call it with no arguments at all, or with a single string, or a single string followed by a `connectInfo` object, or just a `connectInfo` object. That last call signature is disallowed by the current type definition. This PR fixes it.