### PR TITLE
Use object spread (and not intersections) when overriding chrome$Event functions

### DIFF
--- a/interfaces/alarms.js
+++ b/interfaces/alarms.js
@@ -26,7 +26,8 @@ type chrome$alarms = {
   ),
   getAll(callback: (alarms: Array<chrome$Alarm>) => void): void,
 
-  onAlarm: chrome$Event & {
+  onAlarm: {
+    ...chrome$Event,
     addListener(callback: $alarm$AlarmCallback): void
   }
 };

--- a/interfaces/bookmarks.js
+++ b/interfaces/bookmarks.js
@@ -60,18 +60,22 @@ type chrome$bookmarks = {
     callback?: $bookmarks$BookmarkTreeNodeCallback
   ): void,
 
-  onChanged: chrome$Event & {
+  onChanged: {
+    ...chrome$Event,
     addListener(callback: (id: string, changeInfo: {title: string, url?: string}) => void): void
   },
-  onChildrenReordered: chrome$Event & {
+  onChildrenReordered: {
+    ...chrome$Event,
     addListener(callback: (id: string, reorderInfo: Array<string>) => void): void
   },
-  onCreated: chrome$Event & {
+  onCreated: {
+    ...chrome$Event,
     addListener(callback: (id: string, bookmark: chrome$BookmarkTreeNode) => void): void
   },
   onImportBegan: chrome$Event,
   onImportEnded: chrome$Event,
-  onMoved: chrome$Event & {
+  onMoved: {
+    ...chrome$Event,
     addListener(callback: (
       id: string,
       moveInfo: {
@@ -82,7 +86,8 @@ type chrome$bookmarks = {
       }
     ) => void): void
   },
-  onRemoved: chrome$Event & {
+  onRemoved: {
+    ...chrome$Event,
     addListener(callback: (
       id: string,
       removeInfo: {

--- a/interfaces/browserAction.js
+++ b/interfaces/browserAction.js
@@ -18,7 +18,8 @@ type chrome$browserAction  = {
   setPopup(details: {popup: string, tabId?: number}): void,
   setTitle(details: {tabId?: number, title: string}): void,
 
-  onClicked: chrome$Event & {
+  onClicked: {
+    ...chrome$Event,
     addListener(callback: (tab: chrome$Tab) => void): void
   }
 };

--- a/interfaces/certificateProvider.js
+++ b/interfaces/certificateProvider.js
@@ -12,12 +12,14 @@ type chrome$SignRequest = {
 };
 
 type chrome$certificateProvider = {
-  onCertificatesRequested: chrome$Event & {
+  onCertificatesRequested: {
+    ...chrome$Event,
     addListener(callback: (
       reportCallback: (certificates: Array<chrome$CertificateInfo>) => void
     ) => void): void
   },
-  onSignDigestRequested: chrome$Event & {
+  onSignDigestRequested: {
+    ...chrome$Event,
     addListener(callback: (
       request: chrome$SignRequest,
       reportCallback: (signature?: ArrayBuffer) => void

--- a/interfaces/commands.js
+++ b/interfaces/commands.js
@@ -7,7 +7,8 @@ type chrome$Command = {
 type chrome$commands = {
   getAll(callback: (commands: Array<chrome$Command>) => void): void,
 
-  onCommand: chrome$Event & {
+  onCommand: {
+    ...chrome$Event,
     addListener(callback: (command: string) => void): void
   }
 };

--- a/interfaces/contextMenus.js
+++ b/interfaces/contextMenus.js
@@ -61,7 +61,8 @@ type chrome$contextMenus = {
     type?: chrome$ItemType,
   }, callback?: () => void): void,
 
-  onClicked: chrome$Event & {
+  onClicked: {
+    ...chrome$Event,
     addListener(callback: $contextMenus$OnClick): void
   }
 };

--- a/interfaces/cookies.js
+++ b/interfaces/cookies.js
@@ -57,7 +57,8 @@ type chrome$cookies = {
     value?: string
   }, callback?: (cookie: chrome$Cookie) => void): void,
 
-  onChanged: chrome$Event & {
+  onChanged: {
+    ...chrome$Event,
     addListener(callback: (changeInfo: {
       cause: chrome$OnChangedCause,
       cookie: chrome$Cookie,

--- a/interfaces/debugger.js
+++ b/interfaces/debugger.js
@@ -25,10 +25,12 @@ type chrome$debugger = {
   sendCommand(target: chrome$Debuggee, method: string, commandParams?: Object, callback?: (result: Object) => void): void,
   getTargets(callback: (result: Array<chrome$TargetInfo>) => void): void,
 
-  onDetach: chrome$Event & {
+  onDetach: {
+    ...chrome$Event,
     addListener(callback: (source: chrome$Debuggee, reason: chrome$DetachReason) => void): void
   },
-  onEvent: chrome$Event & {
+  onEvent: {
+    ...chrome$Event,
     addListener(callback: (source: chrome$Debuggee, method: string, params?: Object) => void): void
   }
 };

--- a/interfaces/devtools.js
+++ b/interfaces/devtools.js
@@ -32,10 +32,12 @@ type $devtools$inspectedWindow = {
   }): void,
   getResources(callback: (resources: Array<chrome$Resource>) => void): void,
 
-  onResourceAdded: chrome$Event & {
+  onResourceAdded: {
+    ...chrome$Event,
     addListener(callback: (resource: chrome$Resource) => void): void
   },
-  onResourceContentCommitted: chrome$Event & {
+  onResourceContentCommitted: {
+    ...chrome$Event,
     addListener(callback: (resource: chrome$Resource, content: string) => void): void
   }
 };
@@ -47,10 +49,12 @@ type chrome$Request = {
 type $devtools$network = {
   getHAR(callback: (harLog: Object) => void): void,
 
-  onNavigated: chrome$Event & {
+  onNavigated: {
+    ...chrome$Event,
     addListener(callback: (url: string) => void): void
   },
-  onRequestFinished: chrome$Event & {
+  onRequestFinished: {
+    ...chrome$Event,
     addListener(callback: (request: chrome$Request) => void): void
   }
 };
@@ -71,10 +75,12 @@ type chrome$ExtensionPanel = {
   createStatusBarButton(iconPath: string, tooltipText: string, disabled: boolean): chrome$Button,
 
   onHidden: chrome$Event,
-  onSearch: chrome$Event & {
+  onSearch: {
+    ...chrome$Event,
     addListener(callback: (action: string, queryString?: string) => void): void
   },
-  onShown: chrome$Event & {
+  onShown: {
+    ...chrome$Event,
     addListener(callback: (window: any) => void): void
   }
 };

--- a/interfaces/downloads.js
+++ b/interfaces/downloads.js
@@ -135,7 +135,8 @@ type chrome$downloads = {
   show(downloadId: number): void,
   showDefaultFolder(): void,
 
-  onChanged: chrome$Event & {
+  onChanged: {
+    ...chrome$Event,
     addListener(callback: (downloadDelta: {
       canResume?: chrome$BooleanDelta,
       danger?: chrome$StringDelta,
@@ -153,10 +154,12 @@ type chrome$downloads = {
       url?: chrome$StringDelta
     }) => void): void
   },
-  onCreated: chrome$Event & {
+  onCreated: {
+    ...chrome$Event,
     addListener(callback: (downloadItem: chrome$DownloadItem) => void): void
   },
-  onDeterminingFilename: chrome$Event & {
+  onDeterminingFilename: {
+    ...chrome$Event,
     addListener(callback: (
       downloadItem: chrome$DownloadItem,
       suggest: (suggestion?: {
@@ -165,7 +168,8 @@ type chrome$downloads = {
       }) => void
     ) => void): void
   },
-  onErased: chrome$Event & {
+  onErased: {
+    ...chrome$Event,
     addListener(callback: (downloadId: number) => void): void
   },
 };

--- a/interfaces/fileBrowserHandler.js
+++ b/interfaces/fileBrowserHandler.js
@@ -15,7 +15,8 @@ type chrome$fileBrowserHandler = {
     }) => void
   ): void,
 
-  onExecute: chrome$Event & {
+  onExecute: {
+    ...chrome$Event,
     addListener(callback: (id: string, details: chrome$FileHanlderExecuteEventDetails) => void): void
   }
 }

--- a/interfaces/fontSettings.js
+++ b/interfaces/fontSettings.js
@@ -44,19 +44,22 @@ type chrome$fontSettings = {
   }, callback?: () => void): void,
   setMinimumFontSize(details: {pixelSize: number}, callback?: () => void): void,
 
-  onDefaultFixedFontSizeChanged: chrome$Event & {
+  onDefaultFixedFontSizeChanged: {
+    ...chrome$Event,
     addListener(callback: (details: {
       levelOfControl: chrome$LevelOfControl,
       pixelSize: number
     }) => void): void
   },
-  onDefaultFontSizeChanged: chrome$Event & {
+  onDefaultFontSizeChanged: {
+    ...chrome$Event,
     addListener(callback: (details: {
       levelOfControl: chrome$LevelOfControl,
       pixelSize: number
     }) => void): void
   },
-  onFontChanged: chrome$Event & {
+  onFontChanged: {
+    ...chrome$Event,
     addListener(callback: (details: {
       fontId: string,
       genericFamily: chrome$GenericFamily,
@@ -64,7 +67,8 @@ type chrome$fontSettings = {
       script?: chrome$ScriptCode
     }) => void): void
   },
-  onMinimumFontSizeChanged: chrome$Event & {
+  onMinimumFontSizeChanged: {
+    ...chrome$Event,
     addListener(callback: (details: {
       levelOfControl: chrome$LevelOfControl,
       pixelSize: number

--- a/interfaces/identity.js
+++ b/interfaces/identity.js
@@ -16,7 +16,8 @@ type chrome$identity = {
     interactive?: boolean
   }, callback: (responseUrl?: string) => void): void,
   getRedirectURL(path?: string): string,
-  onSignInChanged: chrome$Event & {
+  onSignInChanged: {
+    ...chrome$Event,
     addListener(callback: (account: chrome$AccountInfo, signedIn: boolean) => void): void
   }
 };

--- a/interfaces/idle.js
+++ b/interfaces/idle.js
@@ -7,7 +7,8 @@ type chrome$idle = {
   ) => void): void,
   setDetectionInterval(intervalInSeconds: number): void,
 
-  onStateChanged: chrome$Event & {
+  onStateChanged: {
+    ...chrome$Event,
     addListener(callback: (newState: chrome$IdleState) => void): void
   }
 };

--- a/interfaces/networking.js
+++ b/interfaces/networking.js
@@ -14,7 +14,8 @@ type chrome$networking = {
     finishAuthentication(GUID: string, result: $networking$AuthResult, callback?: () => void): void,
     setNetworkFilter(networks: Array<chrome$NetworkInfo>, callback: () => void): void,
 
-    onCaptivePortalDetected: chrome$Event & {
+    onCaptivePortalDetected: {
+      ...chrome$Event,
       addListener(callback: (networkInfo: chrome$NetworkInfo) => void): void
     }
   }

--- a/interfaces/notifications.js
+++ b/interfaces/notifications.js
@@ -46,19 +46,24 @@ type chrome$notifications = {
   getPermissionLevel(callback: (level: chrome$PermissionLevel) => void): void,
   update(notificationId: string, options: chrome$NotificationOptions, callback?: (wasUpdated: boolean) => void): void,
 
-  onButtonClicked: chrome$Event & {
+  onButtonClicked: {
+    ...chrome$Event,
     addListener(callback: (notificationId: string, buttonIndex: number) => void): void,
   },
-  onClicked: chrome$Event & {
+  onClicked: {
+    ...chrome$Event,
     addListener(callback: (notificationId: string) => void): void,
   },
-  onClosed: chrome$Event & {
+  onClosed: {
+    ...chrome$Event,
     addListener(callback: (notificationId: string, byUser: boolean) => void): void,
   },
-  onPermissionLevelChanged: chrome$Event & {
+  onPermissionLevelChanged: {
+    ...chrome$Event,
     addListener(callback: (level: chrome$PermissionLevel) => void): void,
   },
-  onShowSettings: chrome$Event & {
+  onShowSettings: {
+    ...chrome$Event,
     addListener(callback: () => void): void,
   },
 };

--- a/interfaces/pageAction.js
+++ b/interfaces/pageAction.js
@@ -19,7 +19,8 @@ type chrome$pageAction = {
   }): void,
   show(tabId: number): void,
 
-  onClicked: chrome$Event & {
+  onClicked: {
+    ...chrome$Event,
     addListener(callback: (tab: chrome$Tab) => void): void
   }
 };

--- a/interfaces/permissions.js
+++ b/interfaces/permissions.js
@@ -9,10 +9,12 @@ type chrome$permissions = {
   remove(permissions: chrome$Permissions, callback?: (removed: boolean) => void): void,
   request(permissions: chrome$Permissions, callback?: (granted: boolean) => void): void,
 
-  onAdded: chrome$Event & {
+  onAdded: {
+    ...chrome$Event,
     addListener(callback: (permissions: chrome$Permissions) => void): void
   },
-  onRemoved: chrome$Event & {
+  onRemoved: {
+    ...chrome$Event,
     addListener(callback: (permissions: chrome$Permissions) => void): void
   }
 };

--- a/interfaces/runtime.js
+++ b/interfaces/runtime.js
@@ -74,20 +74,24 @@ type chrome$runtime = {
   setUninstallURL(url: string, callback?: () => void): void,
 
   onBrowserUpdateAvailable: chrome$Event,
-  onConnect: chrome$Event & {
+  onConnect: {
+    ...chrome$Event,
     addListener(callback: (port: chrome$Port) => void): void
   },
-  onConnectExternal: chrome$Event & {
+  onConnectExternal: {
+    ...chrome$Event,
     addListener(ccallback: (port: chrome$Port) => void): void
   },
-  onInstalled: chrome$Event & {
+  onInstalled: {
+    ...chrome$Event,
     addListener(callback: (details: {
       id?: string,
       previousVersion?: string,
       reason: chrome$OnInstalledReason
     }) => void): void
   },
-  onMessage: chrome$Event & {
+  onMessage: {
+    ...chrome$Event,
     addListener(callback: (
       ((
         message: any,
@@ -100,7 +104,8 @@ type chrome$runtime = {
       ) => true | void)
     )): void
   },
-  onMessageExternal: chrome$Event & {
+  onMessageExternal: {
+    ...chrome$Event,
     addListener(callback: (
       ((
         message: any,
@@ -113,13 +118,15 @@ type chrome$runtime = {
       ) => true | void)
     )): void
   },
-  onRestartRequired: chrome$Event & {
+  onRestartRequired: {
+    ...chrome$Event,
     addListener(callback: (reason: chrome$OnRestartRequiredReason) => void): void
   },
   onStartup: chrome$Event,
   onSuspend: chrome$Event,
   onSuspendCanceled: chrome$Event,
-  onUpdateAvailable: chrome$Event & {
+  onUpdateAvailable: {
+    ...chrome$Event,
     addListener(callback: (details: {version: string}) => void): void
   }
 };

--- a/interfaces/signedInDevices.js
+++ b/interfaces/signedInDevices.js
@@ -12,7 +12,8 @@ type chrome$signedInDevices = {
     ((callback: (devices: Array<chrome$DeviceInfo>) => void) => void)
   ),
 
-  onDeviceInfoChange: chrome$Event & {
+  onDeviceInfoChange: {
+    ...chrome$Event,
     addListener(callback: (devices: Array<chrome$Event>) => void): void
   }
 }

--- a/interfaces/storage.js
+++ b/interfaces/storage.js
@@ -22,7 +22,8 @@ type chrome$storage = {
   managed: chrome$StorageArea,
   sync: chrome$StorageArea,
 
-  onChanged: chrome$Event & {
+  onChanged: {
+    ...chrome$Event,
     addListener(callback: (changes: Object, areaName: 'local' | 'managed' | 'sync') => void): void
   }
 };

--- a/interfaces/system.js
+++ b/interfaces/system.js
@@ -38,10 +38,12 @@ type chrome$system = {
     }) => void): void,
     getInfo(callback: (info: Array<chrome$StorageUnitInfo>) => void): void,
 
-    onAttached: chrome$Event & {
+    onAttached: {
+      ...chrome$Event,
       addListener(callback: (info: chrome$StorageUnitInfo) => void): void
     },
-    onDetached: chrome$Event & {
+    onDetached: {
+      ...chrome$Event,
       addListener(callback: (id: string) => void): void
     }
   }

--- a/interfaces/tabs.js
+++ b/interfaces/tabs.js
@@ -248,69 +248,82 @@ type chrome$tabs = {
     ) => void)
   ),
 
-  onActivated: chrome$Event & {
+  onActivated: {
+    ...chrome$Event,
     addListener(callback: (activeInfo: {
       tabId: number,
       windowId: number
     }) => void): void
   },
-  onActiveChanged: chrome$Event & {
+  onActiveChanged: {
+    ...chrome$Event,
     addListener(callback: (tabId: number, selectInfo: {windowId: number}) => void): void
   },
-  onAttached: chrome$Event & {
+  onAttached: {
+    ...chrome$Event,
     addListener(callback: (tabId: number, attachInfo: {
       newPosition: number,
       newWindowId: number
     }) => void): void
   },
-  onCreated: chrome$Event & {
+  onCreated: {
+    ...chrome$Event,
     addListener(callback: (tab: chrome$Tab) => void): void
   },
-  onDetached: chrome$Event & {
+  onDetached: {
+    ...chrome$Event,
     addListener(callback: (tabId: number, detachInfo: {
       oldPosition: number,
       oldWindowId: number
     }) => void): void
   },
-  onHighlightChanged: chrome$Event & {
+  onHighlightChanged: {
+    ...chrome$Event,
     addListener(callback: (selectInfo: {
       tabIds: Array<number>,
       windowId: number
     }) => void): void
   },
-  onHighlighted: chrome$Event & {
+  onHighlighted: {
+    ...chrome$Event,
     addListener(callback: (highlightInfo: {
       tabIds: Array<number>,
       windowId: number
     }) => void): void
   },
-  onMoved: chrome$Event & {
+  onMoved: {
+    ...chrome$Event,
     addListener(callback: (tabId: number, moveInfo: {
       fromIndex: number,
       toIndex: number,
       windowId: number
     }) => void): void
   },
-  onRemoved: chrome$Event & {
+  onRemoved: {
+    ...chrome$Event,
     addListener(callback: (tabId: number, removeInfo: {
       isWindowClosing: boolean,
       windowId: number
     }) => void): void
   },
-  onReplaced: chrome$Event & {
+  onReplaced: {
+    ...chrome$Event,
     addListener(callback: (addedTabIds: number, removedTabId: number) => void): void
   },
-  onSelectionChanged: chrome$Event & {
+  onSelectionChanged: {
+    ...chrome$Event,
     addListener(callback: (tabId: number, selectInfo: {windowId: number}) => void): void
   },
-  onUpdated: chrome$Event & {
+  onUpdated: {
+    ...chrome$Event,
     addListener(callback: (
       tabId: number,
       changeInfo: chrome$TabChangeInfo,
       tab: chrome$Tab
     ) => void): void
   },
-  onZoomChange: chrome$Event & {
+  onZoomChange: {
+    ...chrome$Event,
     addListener(callback: (ZoomChangeInfo: {
       newZoomFactor: number,
       oldZoomFactor: number,

--- a/interfaces/types.js
+++ b/interfaces/types.js
@@ -29,7 +29,8 @@ type chrome$ChromeSetting = {
     value: any
   }, callback?: () => void): void,
 
-  onChange: chrome$Event & {
+  onChange: {
+    ...chrome$Event,
     addListener(callback: (details: {
       incognitoSpecific?: boolean,
       levelOfControl: chrome$LevelOfControl,

--- a/interfaces/webRequest.js
+++ b/interfaces/webRequest.js
@@ -50,7 +50,8 @@ type chrome$FormDataItem = ArrayBuffer;
 type chrome$webRequest = {
   MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES: number,
   handlerBehaviorChanged: (callback: () => void) => void,
-  onBeforeRequest: chrome$Event & {
+  onBeforeRequest: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -72,7 +73,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnBeforeRequestOptions>,
     ): void,
   },
-  onBeforeSendHeaders: chrome$Event & {
+  onBeforeSendHeaders: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -90,7 +92,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnBeforeSendHeadersOptions>,
     ): void,
   },
-  onSendHeaders: chrome$Event & {
+  onSendHeaders: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -108,7 +111,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnSendHeadersOptions>,
     ): void,
   },
-  onHeadersReceived: chrome$Event & {
+  onHeadersReceived: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -128,7 +132,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnHeadersReceivedOptions>,
     ): void,
   },
-  onAuthRequired: chrome$Event & {
+  onAuthRequired: {
+    ...chrome$Event,
     addListener(
       callback: (
         details: {
@@ -155,7 +160,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnAuthRequiredOptions>,
     ): void,
   },
-  onResponseStarted: chrome$Event & {
+  onResponseStarted: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -177,7 +183,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnResponseStartedOptions>,
     ): void,
   },
-  onBeforeRedirect: chrome$Event & {
+  onBeforeRedirect: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -200,7 +207,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnBeforeRedirectOptions>,
     ): void,
   },
-  onCompleted: chrome$Event & {
+  onCompleted: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,
@@ -222,7 +230,8 @@ type chrome$webRequest = {
       extraInfoSpec?: Array<chrome$OnCompletedOptions>,
     ): void,
   },
-  onErrorOccurred: chrome$Event & {
+  onErrorOccurred: {
+    ...chrome$Event,
     addListener(
       callback: (details: {
         requestId: string,

--- a/interfaces/webstore.js
+++ b/interfaces/webstore.js
@@ -27,10 +27,12 @@ type chrome$webstore = {
     failureCallback: (error: string, errorCode?: chrome$ErrorCode) => void
   ): void,
 
-  onDownloadProgress: chrome$Event & {
+  onDownloadProgress: {
+    ...chrome$Event,
     addListener(callback: (percentDownloaded: number) => void): void
   },
-  onInstallStageChanged: chrome$Event & {
+  onInstallStageChanged: {
+    ...chrome$Event,
     addListener(callback: (stage: chrome$InstallStage) => void): void
   }
 };

--- a/interfaces/windows.js
+++ b/interfaces/windows.js
@@ -91,15 +91,18 @@ type chrome$windows = {
     callback?: (window: chrome$Window) => void
   ): void,
 
-  onCreated: chrome$Event & {
+  onCreated: {
+    ...chrome$Event,
     Filters: Array<chrome$WindowType>,
     addListener(callback: (window: chrome$Window) => void): void
   },
-  onFocusChanged: chrome$Event & {
+  onFocusChanged: {
+    ...chrome$Event,
     Filters: Array<chrome$WindowType>,
     addListener(callback: (windowId: number) => void): void
   },
-  onRemoved: chrome$Event & {
+  onRemoved: {
+    ...chrome$Event,
     Filters: Array<chrome$WindowType>,
     addListener(callback: (windowId: number) => void): void
   },


### PR DESCRIPTION
This change implements a fix for [this issue](https://github.com/Shraymonks/flow-interfaces-chrome/issues/23).

The call to chrome.tabs.onUpdated.addListener was giving a flow error[1] in this example:

```javascript
class Foo {
  constructor() {
    chrome.tabs.onUpdated.addListener(this.handleUpdated);
  }

  handleUpdated = (
    tabId: number,
    changeInfo: chrome$TabChangeInfo,
    tab: chrome$Tab,
  ) => {
    // do things
  }
}
```

But not in this one:
```javascript
chrome.tabs.onUpdated.addListener((
  tabId: number,
  changeInfo: chrome$TabChangeInfo,
  tab: chrome$Tab,
) => {
  // do things
});
```

Switching to object spread rather than intersection causes flow to replace the existing addListener handler with our new custom one, and works in both the above cases.

[1] Said error: 
```
function [1] requires another argument from function type [2].
   116|     chrome.tabs.onUpdated.addListener(this.handleUpdated);
                                              ^^^^^^^^^^^^^^^
References:                       v
    62|   tabUpdated = (
    63|     tabId: number,
    64|     changeInfo: chrome$TabChangeInfo,
    65|     tab: chrome$Tab,
    66|   ) => {
    79|   };
          ^ [1]
    10|   addListener(callback: () => void): void,
                                ^^^^^^^^^^ [2]
```