### PR TITLE
Declare storage as using "maps" not Objects

### DIFF
--- a/interfaces/storage.js
+++ b/interfaces/storage.js
@@ -1,20 +1,22 @@
 type chrome$StorageChange = {
   newValue?: any,
-  oldValue?: any
+  oldValue?: any,
 };
 
 type chrome$StorageArea = {
   clear(callback?: () => void): void,
-  get: (
-    ((keys: string | Array<string> | Object | null, callback: (items: Object) => void) => void) &
-    ((callback: (items: Object) => void) => void)
-  ),
-  getBytesInUse: (
-    ((keys: string | Array<string> | null, callback: (bytesInUse: number) => void) => void) &
-    ((callback: (bytesInUse: number) => void) => void)
-  ),
+  get: ((
+    keys: string | Array<string> | { [key: string]: any } | null,
+    callback: (items: { [key: string]: any }) => void
+  ) => void) &
+    ((callback: (items: { [key: string]: any }) => void) => void),
+  getBytesInUse: ((
+    keys: string | Array<string> | null,
+    callback: (bytesInUse: number) => void
+  ) => void) &
+    ((callback: (bytesInUse: number) => void) => void),
   remove(keys: string | Array<string>, callback?: () => void): void,
-  set(items: Object, callback?: () => void): void
+  set(items: { [key: string]: any }, callback?: () => void): void,
 };
 
 type chrome$storage = {
@@ -24,6 +26,8 @@ type chrome$storage = {
 
   onChanged: {
     ...chrome$Event,
-    addListener(callback: (changes: Object, areaName: 'local' | 'managed' | 'sync') => void): void
-  }
+    addListener(
+      callback: (changes: { [key: string]: any }, areaName: 'local' | 'managed' | 'sync') => void
+    ): void,
+  },
 };


### PR DESCRIPTION
The `Object` type has become stricter in Flow and means an Object with a
defined set of keys. WebStorage uses JS Objects as "maps," and Flow's
syntax for that use is `{ [key: string]: any}`. This offers slightly
more correct types and ensures calls to `get`, `set`, etc. can be
correctly chosen by ~0.90.0+ versions of Flow.